### PR TITLE
[#97] Add --data flag to dev.sh for seeding database

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SEED_DATA=false
+
+for arg in "$@"; do
+	case "$arg" in
+		--data)
+			SEED_DATA=true
+			;;
+		*)
+			echo "Unknown option: $arg"
+			echo "Usage: ./dev.sh [--data]"
+			exit 1
+			;;
+	esac
+done
+
 if ! command -v docker >/dev/null 2>&1; then
 	echo "Error: Docker CLI ('docker') is not installed or not on PATH."
 	echo "Install Docker Desktop/Engine and re-run this script from a host shell with Docker access."
@@ -16,4 +31,16 @@ fi
 echo "==> Starting dev environment with hot reload..."
 
 docker compose -f docker-compose.yml -f docker-compose.dev.yml down -v --remove-orphans
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
+
+if [ "$SEED_DATA" = true ]; then
+	echo "waiting for containers before seeding data..."
+	sleep 10
+ 
+
+	echo "seeding database with sample data..."
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml exec backend python manage.py seed_data
+fi
+
+echo "attaching to logs....."
+docker compose -f docker-compose.yml -f docker-compose.dev.yml logs -f


### PR DESCRIPTION
Adds a --data flag to dev.sh to allow seeding the database on startup.

Usage:

./dev.sh --data